### PR TITLE
remove typo from SQL query (extra 'w' after b.title)

### DIFF
--- a/core/sql_queries/utils/scripts.py
+++ b/core/sql_queries/utils/scripts.py
@@ -87,7 +87,7 @@ teams_bought = """
 WITH ranked_books AS (
     SELECT
         bs.list_id,
-        b.title,w
+        b.title,
         bs.rank,
         d."date"
     FROM nyt_books.main_models.best_sellers_facts AS bs


### PR DESCRIPTION
There was a 'w' character after one of the columns that I did not notice yesterday. This PR removes that character.